### PR TITLE
Review change to es module server setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,31 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+*.DS_Store
+.DS_Store
+*package-lock.json
+package-lock.json
+*node_modules
 *settings.json
 settings.json
 *.DS_Store

--- a/network/api/api.js
+++ b/network/api/api.js
@@ -1,6 +1,16 @@
-import {addNode, deleteNode, updateNode} from "./apiFunctions"
+import {addNode, deleteNode, updateNode} from "./apiFunctions.js"
+import { Router } from "express";
 import dotenv from "dotenv";
+
 dotenv.config()
+
+const app = Router();
+
+// Sample endpoints
+app.get('/testRoutes', (req, res) => {
+    // ".../api/testRoutes" to test directly in browser
+    res.json({ message: 'Hello from the API routes!' });
+});
 
 app.post('/addNode', (req, res) => {
     // TODO: Add schema validation
@@ -39,3 +49,5 @@ app.post('/updateNode', (req, res) => {
         res.json(returnVal);
     });
 });
+
+export default app;

--- a/network/api/apiServer.js
+++ b/network/api/apiServer.js
@@ -11,7 +11,8 @@ app.use(express.json()); // To parse JSON request bodies
 app.use("/api", apiapp);
 
 // Sample endpoint
-app.get('/api/message', (req, res) => {
+app.get('/message', (req, res) => {
+    // ".../message" to test directly in browser
     res.json({ message: 'Hello from the server!' });
 });
 

--- a/network/api/apiServer.js
+++ b/network/api/apiServer.js
@@ -1,10 +1,14 @@
 // server.js
-const express = require('express');
-const cors = require('cors');
+import express from 'express';
+import cors from 'cors';
+import apiapp from './api.js';
+
 const app = express();
 
 app.use(cors());
 app.use(express.json()); // To parse JSON request bodies
+
+app.use("/api", apiapp);
 
 // Sample endpoint
 app.get('/api/message', (req, res) => {

--- a/network/api/package.json
+++ b/network/api/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "api",
+  "version": "0.0.1",
+  "type": "module",
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.651.1",
+    "@aws-sdk/lib-dynamodb": "^3.651.1",
+    "@types/cors": "^2.8.17",
+    "ajv": "^8.17.1",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.21.1",
+    "node": "^21.7.1",
+    "nodemon": "^3.1.7",
+    "process": "^0.11.10"
+  }
+}


### PR DESCRIPTION
I made this branch because there were some complicated changes I made in reviewing/testing so I knew even what to leave on the review. In short, this basically sets up the package.json, apiServer, and api.js to be an ES Module. Meaning, we can import and export our routes (or 'apps') for ease of development. This follows the same model as our experiment project. 